### PR TITLE
Support horizontal mouse wheel scrolling

### DIFF
--- a/src/main/java/com/raylib/java/core/Callbacks.java
+++ b/src/main/java/com/raylib/java/core/Callbacks.java
@@ -1,5 +1,6 @@
 package com.raylib.java.core;
 
+import com.raylib.java.raymath.Vector2;
 import org.lwjgl.glfw.*;
 
 import static com.raylib.java.Config.*;
@@ -174,7 +175,7 @@ public class Callbacks{
         @Override
         public void invoke(long window, double xoffset, double yoffset){
             Tracelog(LOG_DEBUG, "Scroll Callback Triggered");
-            rCore.getInput().mouse.setCurrentWheelMove((float) yoffset);
+            rCore.getInput().mouse.setCurrentWheelMove(new Vector2((float) xoffset, (float) yoffset));
         }
     }
 

--- a/src/main/java/com/raylib/java/core/input/Mouse.java
+++ b/src/main/java/com/raylib/java/core/input/Mouse.java
@@ -15,8 +15,8 @@ public class Mouse{
 
     public int[] currentButtonState;     // Registers current mouse button state
     public int[] previousButtonState;    // Registers previous mouse button state
-    public float currentWheelMove;         // Registers current mouse wheel variation
-    public float previousWheelMove;        // Registers previous mouse wheel variation
+    public Vector2 currentWheelMove;         // Registers current mouse wheel variation
+    public Vector2 previousWheelMove;        // Registers previous mouse wheel variation
 
 
     // Mouse buttons
@@ -131,19 +131,19 @@ public class Mouse{
         this.previousButtonState = previousButtonState;
     }
 
-    public float getCurrentWheelMove(){
+    public Vector2 getCurrentWheelMove(){
         return currentWheelMove;
     }
 
-    public void setCurrentWheelMove(float currentWheelMove){
+    public void setCurrentWheelMove(Vector2 currentWheelMove){
         this.currentWheelMove = currentWheelMove;
     }
 
-    public float getPreviousWheelMove(){
+    public Vector2 getPreviousWheelMove(){
         return previousWheelMove;
     }
 
-    public void setPreviousWheelMove(float previousWheelMove){
+    public void setPreviousWheelMove(Vector2 previousWheelMove){
         this.previousWheelMove = previousWheelMove;
     }
 }

--- a/src/main/java/com/raylib/java/core/rCore.java
+++ b/src/main/java/com/raylib/java/core/rCore.java
@@ -2241,9 +2241,17 @@ public class rCore{
         input.mouse.setScale(new Vector2(scaleX, scaleY));
     }
 
-    // Returns mouse wheel movement Y
+    // Get mouse wheel movement for X or Y, whichever is larger
     public static float GetMouseWheelMove(){
-        return input.mouse.getPreviousWheelMove();
+        return Math.max(
+                input.mouse.currentWheelMove.getX(),
+                input.mouse.currentWheelMove.getY()
+        );
+    }
+
+    // Get mouse wheel movement X/Y as a vector
+    public static Vector2 GetMouseWheelMoveV(){
+        return new Vector2(input.mouse.currentWheelMove.getX(), input.mouse.currentWheelMove.getY());
     }
 
     // Set mouse cursor
@@ -2787,7 +2795,7 @@ public class rCore{
 
         // Register previous mouse wheel state
         input.mouse.setPreviousWheelMove(input.mouse.getCurrentWheelMove());
-        input.mouse.setCurrentWheelMove(0.0f);
+        input.mouse.setCurrentWheelMove(Vector2Zero());
 
         // Check if gamepads are ready
         // NOTE: We do it here in case of disconnection
@@ -3109,11 +3117,11 @@ public class rCore{
         }
 
         // INPUT_MOUSE_WHEEL_MOTION
-        if ((int)input.mouse.currentWheelMove != (int)input.mouse.previousWheelMove) {
+        if (input.mouse.currentWheelMove.getX() != input.mouse.previousWheelMove.getX() || input.mouse.currentWheelMove.getY() != input.mouse.previousWheelMove.getY()){
             events.get(eventCount).frame = frame;
             events.get(eventCount).type = INPUT_MOUSE_WHEEL_MOTION;
-            events.get(eventCount).params[0] = (int)input.mouse.currentWheelMove;
-            events.get(eventCount).params[1] = 0;
+            events.get(eventCount).params[0] = (int) input.mouse.currentWheelMove.getX();
+            events.get(eventCount).params[1] = (int) input.mouse.currentWheelMove.getY();
             events.get(eventCount).params[2] = 0;
 
             Tracelog(LOG_INFO, "[" + events.get(eventCount).frame + "] INPUT_MOUSE_WHEEL_MOTION: " + events.get(eventCount).params[0] + ", " + events.get(eventCount).params[1] + ", " + events.get(eventCount).params[2]);
@@ -3257,7 +3265,7 @@ public class rCore{
                         input.mouse.currentPosition.y = (float)events.get(i).params[1];
                         break;
                     case INPUT_MOUSE_WHEEL_MOTION:   // param[0]: delta
-                        input.mouse.currentWheelMove = (float)events.get(i).params[0];
+                        input.mouse.currentWheelMove = new Vector2(0.0f, (float) events.get(i).params[0]);
                         break;
                     case INPUT_TOUCH_UP:     // param[0]: id
                         input.touch.currentTouchState[events.get(i).params[0]] = false;

--- a/src/main/java/com/raylib/java/core/rCore.java
+++ b/src/main/java/com/raylib/java/core/rCore.java
@@ -3265,7 +3265,7 @@ public class rCore{
                         input.mouse.currentPosition.y = (float)events.get(i).params[1];
                         break;
                     case INPUT_MOUSE_WHEEL_MOTION:   // param[0]: delta
-                        input.mouse.currentWheelMove = new Vector2(0.0f, (float) events.get(i).params[0]);
+                        input.mouse.currentWheelMove = new Vector2((float) events.get(i).params[1], (float) events.get(i).params[0]);
                         break;
                     case INPUT_TOUCH_UP:     // param[0]: id
                         input.touch.currentTouchState[events.get(i).params[0]] = false;

--- a/src/main/java/com/raylib/java/core/rcamera/Camera3D.java
+++ b/src/main/java/com/raylib/java/core/rcamera/Camera3D.java
@@ -109,7 +109,7 @@ public class Camera3D {
         // Mouse movement detection
         Vector2 mousePositionDelta = new Vector2(0.0f, 0.0f);
         Vector2 mousePosition = rCore.GetMousePosition();
-        Vector2 mouseWheelMove = rCore.GetMouseWheelMove();
+        float mouseWheelMove = rCore.GetMouseWheelMove();
 
         // Keys input detection
         // TODO: Input detection is raylib-dependant, it could be moved outside the module
@@ -138,45 +138,45 @@ public class Camera3D {
         switch (cameraData.mode) {
             case CameraMode.CAMERA_FREE: {          // rCamera free controls, using standard 3d-content-creation scheme
                 // rCamera zoom
-                if ((cameraData.targetDistance < CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
-                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                if ((cameraData.targetDistance < CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
+                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance > CAMERA_FREE_DISTANCE_MAX_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MAX_CLAMP;
                     }
                 }
 
                 // rCamera looking down
-                else if ((position.y > target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
-                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                else if ((position.y > target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
+                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
                 }
                 else if ((position.y > target.y) && (target.y >= 0)){
-                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
 
                     // if (target.y < 0) target.y = -0.001;
-                } else if ((position.y > target.y) && (target.y < 0) && (mouseWheelMove.getY() > 0)){
-                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                } else if ((position.y > target.y) && (target.y < 0) && (mouseWheelMove > 0)){
+                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance < CAMERA_FREE_DISTANCE_MIN_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MIN_CLAMP;
                     }
                 }
                 // rCamera looking up
-                else if ((position.y < target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
-                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                else if ((position.y < target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
+                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
                 }
                 else if ((position.y < target.y) && (target.y <= 0)){
-                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
 
                     // if (target.y > 0) target.y = 0.001;
-                } else if ((position.y < target.y) && (target.y > 0) && (mouseWheelMove.getY() > 0)){
-                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                } else if ((position.y < target.y) && (target.y > 0) && (mouseWheelMove > 0)){
+                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance < CAMERA_FREE_DISTANCE_MIN_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MIN_CLAMP;
                     }
@@ -222,7 +222,7 @@ public class Camera3D {
             break;
             case CameraMode.CAMERA_ORBITAL: {        // rCamera just orbits around target, only zoom allowed
                 cameraData.angle.x += CAMERA_ORBITAL_SPEED;      // rCamera orbit angle
-                cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);   // rCamera zoom
+                cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);   // rCamera zoom
 
                 // rCamera distance clamp
                 if (cameraData.targetDistance < CAMERA_THIRD_PERSON_DISTANCE_CLAMP) {
@@ -320,7 +320,7 @@ public class Camera3D {
                 }
 
                 // rCamera zoom
-                cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
 
                 // rCamera distance clamp
                 if (cameraData.targetDistance < CAMERA_THIRD_PERSON_DISTANCE_CLAMP){

--- a/src/main/java/com/raylib/java/core/rcamera/Camera3D.java
+++ b/src/main/java/com/raylib/java/core/rcamera/Camera3D.java
@@ -109,7 +109,7 @@ public class Camera3D {
         // Mouse movement detection
         Vector2 mousePositionDelta = new Vector2(0.0f, 0.0f);
         Vector2 mousePosition = rCore.GetMousePosition();
-        float mouseWheelMove = rCore.GetMouseWheelMove();
+        Vector2 mouseWheelMove = rCore.GetMouseWheelMove();
 
         // Keys input detection
         // TODO: Input detection is raylib-dependant, it could be moved outside the module
@@ -138,47 +138,45 @@ public class Camera3D {
         switch (cameraData.mode) {
             case CameraMode.CAMERA_FREE: {          // rCamera free controls, using standard 3d-content-creation scheme
                 // rCamera zoom
-                if ((cameraData.targetDistance < CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
-                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                if ((cameraData.targetDistance < CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
+                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance > CAMERA_FREE_DISTANCE_MAX_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MAX_CLAMP;
                     }
                 }
 
                 // rCamera looking down
-                else if ((position.y > target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
-                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                else if ((position.y > target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
+                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
                 }
                 else if ((position.y > target.y) && (target.y >= 0)){
-                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
 
                     // if (target.y < 0) target.y = -0.001;
-                }
-                else if ((position.y > target.y) && (target.y < 0) && (mouseWheelMove > 0)){
-                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                } else if ((position.y > target.y) && (target.y < 0) && (mouseWheelMove.getY() > 0)){
+                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance < CAMERA_FREE_DISTANCE_MIN_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MIN_CLAMP;
                     }
                 }
                 // rCamera looking up
-                else if ((position.y < target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove < 0)){
-                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                else if ((position.y < target.y) && (cameraData.targetDistance == CAMERA_FREE_DISTANCE_MAX_CLAMP) && (mouseWheelMove.getY() < 0)){
+                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
                 }
                 else if ((position.y < target.y) && (target.y <= 0)){
-                    target.x += mouseWheelMove * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.y += mouseWheelMove * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
-                    target.z += mouseWheelMove * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.x += mouseWheelMove.getY() * (target.x - position.x) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.y += mouseWheelMove.getY() * (target.y - position.y) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
+                    target.z += mouseWheelMove.getY() * (target.z - position.z) * CAMERA_MOUSE_SCROLL_SENSITIVITY / cameraData.targetDistance;
 
                     // if (target.y > 0) target.y = 0.001;
-                }
-                else if ((position.y < target.y) && (target.y > 0) && (mouseWheelMove > 0)){
-                    cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                } else if ((position.y < target.y) && (target.y > 0) && (mouseWheelMove.getY() > 0)){
+                    cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
                     if (cameraData.targetDistance < CAMERA_FREE_DISTANCE_MIN_CLAMP) {
                         cameraData.targetDistance = CAMERA_FREE_DISTANCE_MIN_CLAMP;
                     }
@@ -224,7 +222,7 @@ public class Camera3D {
             break;
             case CameraMode.CAMERA_ORBITAL: {        // rCamera just orbits around target, only zoom allowed
                 cameraData.angle.x += CAMERA_ORBITAL_SPEED;      // rCamera orbit angle
-                cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);   // rCamera zoom
+                cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);   // rCamera zoom
 
                 // rCamera distance clamp
                 if (cameraData.targetDistance < CAMERA_THIRD_PERSON_DISTANCE_CLAMP) {
@@ -322,7 +320,7 @@ public class Camera3D {
                 }
 
                 // rCamera zoom
-                cameraData.targetDistance -= (mouseWheelMove * CAMERA_MOUSE_SCROLL_SENSITIVITY);
+                cameraData.targetDistance -= (mouseWheelMove.getY() * CAMERA_MOUSE_SCROLL_SENSITIVITY);
 
                 // rCamera distance clamp
                 if (cameraData.targetDistance < CAMERA_THIRD_PERSON_DISTANCE_CLAMP){


### PR DESCRIPTION
This feature required the following changes:

- Change type of `currentWheelMove` and `previousWheelMove` from `float` to `Vector2`
- Change implementation of `GetMouseWheelMove` to match raylib (Return the mouse wheel axis with the most movement, not just the Y axis)
- Add `GetMouseWheelMoveV` function
- Appending all old accesses of either member variable with `.getY()`

**NOTE:** This is untested! (hence Draft status) I haven't been able to successfully build with the new build system. As soon as I am able I will test these changes.

This PR will increase raylib coverage (raylib.h/raymath.h) from 75.29% (at 4c7478e) to 75.44% (0.15% increase, one method added).