### PR TITLE
Bug fix with Vector2MoveTowards

### DIFF
--- a/src/main/java/com/raylib/java/raymath/Raymath.java
+++ b/src/main/java/com/raylib/java/raymath/Raymath.java
@@ -322,8 +322,11 @@ public class Raymath{
         float dy = target.y - v.y;
         float value = (dx * dx) + (dy * dy);
 
-        if (value == 0 || maxDistance >= 0 && value <= maxDistance * maxDistance)
-            result = target;
+        if (value == 0 || maxDistance >= 0 && value <= maxDistance * maxDistance) {
+            result.x = target.x;
+            result.y = target.y;
+            return result;
+        }
 
         float dist = (float) Math.sqrt(value);
 
@@ -501,7 +504,7 @@ public class Raymath{
     public static Vector3 Vector3Normalize(Vector3 v){
         Vector3 result = new Vector3();
         result.x = v.x;
-        result.y= v.y;
+        result.y = v.y;
         result.z = v.z;
 
         float length, ilength;


### PR DESCRIPTION
Currently, the "goal" vector passed into the method, and then the "result" rector is changed to reference the "goal" vector. This results in the "goal" vector being changed when it shouldn't be.

Additionally, the "result" vector should be returned within the if statement, else the "v" vector will be moved beyond the "goal" vector.

This has been fixed here by directly assigning the x and y variables within the "result" vector instead of assigning by reference, and then returning the result immediately.

Another, very small change, includes adding a space before the equals symbol at line 507. This is just to match the formatting of the rest of the code, and does not have any functional purpose.

I've tested this extensively within my debugger, and the change seems to work fine.

Many thanks!